### PR TITLE
Fix JWT secret configuration

### DIFF
--- a/src/main/java/com/abc_berkut/utils/JwtUtil.java
+++ b/src/main/java/com/abc_berkut/utils/JwtUtil.java
@@ -3,18 +3,22 @@ package com.abc_berkut.utils;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import java.nio.charset.StandardCharsets;
 
 import java.security.Key;
 import java.util.Date;
 
 @Component
 public class JwtUtil {
-    private final String jwtSecret = "SUPER_SECRET_KEY";
-    private final long jwtExpirationMs = 86400000; // 1 день
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+    @Value("${jwt.expiration:86400000}")
+    private long jwtExpirationMs; // 1 день
 
     private Key getSigningKey() {
-        return Keys.hmacShaKeyFor(jwtSecret.getBytes());
+        return Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
     }
 
     public String generateToken(String username) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,5 @@ spring.jpa.properties.hibernate.format_sql=true
 telegram.bot.username=mozestroBot
 telegram.bot.token=8091490625:AAEJp9xrodaE7gVgT3b7E5zqo5y0KRRPjZQ
 
+jwt.secret=0123456789abcdef0123456789abcdef
+


### PR DESCRIPTION
## Summary
- inject JWT secret via `application.properties`
- use `StandardCharsets.UTF_8` for key bytes

## Testing
- `./gradlew test --console=plain` *(fails: Cannot find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_683f50a415b8832a81c7f3f9dcfa4d5f